### PR TITLE
Fix windows compilation

### DIFF
--- a/source/FAST/DataPort.hpp
+++ b/source/FAST/DataPort.hpp
@@ -13,6 +13,7 @@ enum StreamingMode { STREAMING_MODE_NEWEST_FRAME_ONLY, STREAMING_MODE_STORE_ALL_
 class ProcessObject;
 
 class DataPort {
+	typedef unsigned int uint;
     public:
         explicit DataPort(SharedPointer<ProcessObject> processObject);
 

--- a/source/FAST/Visualization/VertexRenderer/VertexRenderer.cpp
+++ b/source/FAST/Visualization/VertexRenderer/VertexRenderer.cpp
@@ -169,6 +169,7 @@ uint VertexRenderer::addInputData(Mesh::pointer data, Color color, float size) {
     uint nr = addInputData(data);
     setColor(nr, color);
     setSize(nr, size);
+	return nr;
 }
 
 


### PR DESCRIPTION
Small fixes from compiling on Windows in VS2013.

## Fixed ##
* `uint` isn't a built in type in VS2013, so I added a typedef to the `DataPort` class.
* Return value was missing from a function in the `VertexRenderer`. I assume you meant to return the uint value `nr` that's declared in that function. 