### PR TITLE
Added Custom Command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,6 @@ configure_file(
     "${PROJECT_SOURCE_DIR}/source/ProcessObjectList.hpp.in"
     "${PROJECT_BINARY_DIR}/ProcessObjectList.hpp"
 )
-
+include(cmake/FASTCustomCommands.cmake)
 include(cmake/ModulePython.cmake)
 include(cmake/InstallFAST.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,12 @@ configure_file(
     "${PROJECT_SOURCE_DIR}/source/ProcessObjectList.hpp.in"
     "${PROJECT_BINARY_DIR}/ProcessObjectList.hpp"
 )
-include(cmake/FASTCustomCommands.cmake)
+
+if(NOT FAST_BUILD_QT5 AND WIN32)
+    # Using pre-built binaries on Windows so add custom command to copy 
+    # dlls automatically to the bin folder. 
+    include(cmake/FASTCustomCommands.cmake)
+endif(NOT FAST_BUILD_QT5 AND WIN32)
+
 include(cmake/ModulePython.cmake)
 include(cmake/InstallFAST.cmake)

--- a/cmake/FASTCustomCommands.cmake
+++ b/cmake/FASTCustomCommands.cmake
@@ -1,0 +1,7 @@
+
+add_custom_command(TARGET FAST POST_BUILD 
+	COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:Qt5::Core> $<TARGET_FILE_DIR:FAST>
+	COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:Qt5::Widgets> $<TARGET_FILE_DIR:FAST>
+	COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:Qt5::Gui> $<TARGET_FILE_DIR:FAST>
+	COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:Qt5::OpenGL> $<TARGET_FILE_DIR:FAST>
+)


### PR DESCRIPTION
Added a custom command in cmake that runs after FAST is built and copies over the needed Qt5 binaries to the build directory of FAST so that the examples and tests run without complaining of missing dlls (on windows).