### PR TITLE
Update Zlib Linking for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,12 @@
 
 project(FAST)
 
+# set policies explicitly to avoid warnings.
+# Read more on CMP0022 here: https://cmake.org/cmake/help/v3.0/policy/CMP0022.html
+# This was set as a fix for windows builds where FAST was expecting the name of
+# the zlib library to be 'zlib' when it was in fact 'zlibd'.
+cmake_policy(SET CMP0022 NEW)
+
 include(cmake/Macros.cmake)
 
 #### Options

--- a/cmake/ExternalZlib.cmake
+++ b/cmake/ExternalZlib.cmake
@@ -16,7 +16,7 @@ ExternalProject_Add(zlib
             -DCMAKE_INSTALL_PREFIX:STRING=${FAST_EXTERNAL_INSTALL_DIR}
 )
 if(WIN32)
-	set(ZLIB_LIBRARY zlib.lib)
+	set(ZLIB_LIBRARY debug zlibd.lib optimized zlib.lib)
 else(WIN32)
 	set(ZLIB_LIBRARY ${CMAKE_SHARED_LIBRARY_PREFIX}z${CMAKE_SHARED_LIBRARY_SUFFIX})
 endif(WIN32)


### PR DESCRIPTION
Changed how zlib is linked to on windows to take into account how libs are named in debug (i.e. zlibd vs zlib).