### PR TITLE
Improved reporter messages and inheritable ImageFileStreamer

### DIFF
--- a/source/FAST/ProcessObject.cpp
+++ b/source/FAST/ProcessObject.cpp
@@ -92,11 +92,10 @@ void ProcessObject::update(int executeToken) {
     if(mIsModified || newInputData) {
         this->mRuntimeManager->startRegularTimer("execute");
         // set isModified to false before executing to avoid recursive update calls
-        reportInfo() << "EXECUTING " << getNameOfClass() << " because " << reportEnd();
         if(mIsModified) {
-            reportInfo() << "PO is modified." << reportEnd();
+            reportInfo() << "EXECUTING " << getNameOfClass() << " because PO is modified." << reportEnd();
         } else if(newInputData) {
-            reportInfo() << "has new input data." << reportEnd();
+            reportInfo() << "EXECUTING " << getNameOfClass() << " because PO has new input data." << reportEnd();
         }
         mIsModified = false;
         preExecute();

--- a/source/FAST/Reporter.hpp
+++ b/source/FAST/Reporter.hpp
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <iostream>
+#include <thread>
 #include "FASTExport.hpp"
 
 #undef ERROR // undefine some windows garbage
@@ -51,11 +52,11 @@ void Reporter::process(const T& content) {
         // Write prefix first
         if(reportMethod == COUT) {
             if(mType == INFO) {
-                std::cout << "INFO: ";
+                std::cout << "INFO [" << std::this_thread::get_id() << "] ";
             } else if(mType == WARNING) {
-                std::cout << "WARNING: ";
+                std::cout << "WARNING [" << std::this_thread::get_id() << "] ";
             } else if(mType == ERROR) {
-                std::cout << "ERROR: ";
+                std::cout << "ERROR [" << std::this_thread::get_id() << "] ";
             }
         }
         mFirst = false;

--- a/source/FAST/Streamers/ImageFileStreamer.hpp
+++ b/source/FAST/Streamers/ImageFileStreamer.hpp
@@ -8,7 +8,7 @@ class FAST_EXPORT ImageFileStreamer : public FileStreamer {
     FAST_OBJECT(ImageFileStreamer)
     protected:
         DataObject::pointer getDataFrame(std::string filename) override;
-    private:
+
         ImageFileStreamer();
 
 };

--- a/source/FAST/Streamers/Streamer.cpp
+++ b/source/FAST/Streamers/Streamer.cpp
@@ -36,9 +36,11 @@ void Streamer::stop() {
         std::unique_lock<std::mutex> lock(m_stopMutex);
         m_stop = true;
     }
-    if(m_thread)
+    if(m_thread) {
         m_thread->join();
-    reportInfo() << "Streamer thread for " << getNameOfClass() << " returned" << reportEnd();
+        m_thread = NULL;
+        reportInfo() << "Streamer thread for " << getNameOfClass() << " returned" << reportEnd();
+    }
 }
 
 }


### PR DESCRIPTION
add threadid in reporter messages
ImageFileStreamer constructor protected
Streamer::stop() callable multiple times without crash