### PR TITLE
Bug fix for View and PipelineHighlighter classes (2nd attempt)

### DIFF
--- a/source/FAST/PipelineEditor.hpp
+++ b/source/FAST/PipelineEditor.hpp
@@ -33,25 +33,25 @@ class FAST_EXPORT PipelineEditor : public QWidget {
 };
 
 
-class PipelineHighlighter : public QSyntaxHighlighter {
+class FAST_EXPORT PipelineHighlighter : public QSyntaxHighlighter {
     Q_OBJECT
 
-public:
-    PipelineHighlighter(QTextDocument* parent = 0);
+	public:
+		PipelineHighlighter(QTextDocument* parent = 0);
 
-protected:
-    void highlightBlock(const QString& text) override;
+	protected:
+		void highlightBlock(const QString& text) override;
 
-private:
-    struct HighlightingRule {
-        QRegularExpression pattern;
-        QTextCharFormat format;
-    };
-    QVector<HighlightingRule> highlightingRules;
+	private:
+		struct HighlightingRule {
+			QRegularExpression pattern;
+			QTextCharFormat format;
+		};
+		QVector<HighlightingRule> highlightingRules;
 
-    QTextCharFormat keywordFormat;
-    QTextCharFormat singleLineCommentFormat;
-    QTextCharFormat quotationFormat;
+		QTextCharFormat keywordFormat;
+		QTextCharFormat singleLineCommentFormat;
+		QTextCharFormat quotationFormat;
 };
 
 }

--- a/source/FAST/Visualization/View.cpp
+++ b/source/FAST/Visualization/View.cpp
@@ -7,6 +7,7 @@
 #include "SimpleWindow.hpp"
 #include "FAST/Utility.hpp"
 #include <QGLFunctions>
+#include <algorithm>
 
 #if defined(__APPLE__) || defined(__MACOSX)
 #include <OpenCL/cl_gl.h>
@@ -45,8 +46,8 @@ void View::addRenderer(Renderer::pointer renderer) {
 
 void View::removeRenderer(Renderer::pointer rendererToRemove) {
     std::lock_guard<std::mutex> lock(m_mutex);
-    mVolumeRenderers.erase(std::find(mVolumeRenderers.begin(), mVolumeRenderers.end(), rendererToRemove));
-    mNonVolumeRenderers.erase(std::find(mNonVolumeRenderers.begin(), mNonVolumeRenderers.end(), rendererToRemove));
+	mVolumeRenderers.erase(std::remove(mVolumeRenderers.begin(), mVolumeRenderers.end(), rendererToRemove), mVolumeRenderers.end());
+    mNonVolumeRenderers.erase(std::remove(mNonVolumeRenderers.begin(), mNonVolumeRenderers.end(), rendererToRemove), mNonVolumeRenderers.end());
 }
 
 void View::removeAllRenderers() {


### PR DESCRIPTION
As discussed earlier. Needed to make a new, fresh pull request due to some issues during merge.

Also, regarding the View class (removeRenderer method) my approach can be explained from here:
https://stackoverflow.com/questions/3385229/c-erase-vector-element-by-value-rather-than-by-position/3385251#3385251

There was also a comment stating that it is necessary to include the "algorithm" library as well, so I did that also. However, I did not see the mentioned errors if it was not included. 

I've tested the fixes using FastPathology on my Windows10 laptop using the most recent commit of FAST.