### PR TITLE
Bug fix regarding import/export not being executed

### DIFF
--- a/source/FAST/Algorithms/ImagePatch/PatchGenerator.hpp
+++ b/source/FAST/Algorithms/ImagePatch/PatchGenerator.hpp
@@ -19,11 +19,13 @@ class FAST_EXPORT PatchGenerator : public Streamer {
          */
         void setOverlap(float percent);
         void setPatchLevel(int level);
+        void setMaskThreshold(float percent);
         ~PatchGenerator();
         void loadAttributes() override;
     protected:
         int m_width, m_height, m_depth;
         float m_overlapPercent = 0;
+        float m_maskThreshold = 0.5;
 
         std::shared_ptr<ImagePyramid> m_inputImagePyramid;
         std::shared_ptr<Image> m_inputVolume;

--- a/source/FAST/Algorithms/Morphology/Dilation.cpp
+++ b/source/FAST/Algorithms/Morphology/Dilation.cpp
@@ -8,6 +8,12 @@ Dilation::Dilation() {
     createOutputPort<Image>(0);
     createOpenCLProgram(Config::getKernelSourcePath() + "Algorithms/Morphology/Dilation.cl");
     mSize = 3;
+
+    createIntegerAttribute("kernel-size", "Kernel size", "Kernel size used for dilation", mSize);
+}
+
+void Dilation::loadAttributes() {
+    setStructuringElementSize(getIntegerAttribute("kernel-size"));
 }
 
 void Dilation::setStructuringElementSize(int size) {

--- a/source/FAST/Algorithms/Morphology/Dilation.hpp
+++ b/source/FAST/Algorithms/Morphology/Dilation.hpp
@@ -12,9 +12,10 @@ public:
      * @param size
      */
     void setStructuringElementSize(int size);
+    void loadAttributes() override;
 private:
     Dilation();
-    void execute();
+    void execute() override;
 
     int mSize;
 

--- a/source/FAST/Algorithms/Morphology/Erosion.cpp
+++ b/source/FAST/Algorithms/Morphology/Erosion.cpp
@@ -8,6 +8,12 @@ Erosion::Erosion() {
     createOutputPort<Image>(0);
     createOpenCLProgram(Config::getKernelSourcePath() + "Algorithms/Morphology/Erosion.cl");
     mSize = 3;
+
+    createIntegerAttribute("kernel-size", "Kernel size", "Kernel size used for erosion", mSize);
+}
+
+void Erosion::loadAttributes() {
+    setStructuringElementSize(getIntegerAttribute("kernel-size"));
 }
 
 void Erosion::setStructuringElementSize(int size) {

--- a/source/FAST/Algorithms/Morphology/Erosion.hpp
+++ b/source/FAST/Algorithms/Morphology/Erosion.hpp
@@ -11,9 +11,10 @@ namespace fast {
          * @param size
          */
         void setStructuringElementSize(int size);
+        void loadAttributes() override;
     private:
         Erosion();
-        void execute();
+        void execute() override;
 
         int mSize;
 

--- a/source/FAST/Algorithms/NeuralNetwork/TensorToSegmentation.cpp
+++ b/source/FAST/Algorithms/NeuralNetwork/TensorToSegmentation.cpp
@@ -37,7 +37,7 @@ void TensorToSegmentation::execute() {
     int outputDepth = 1;
     auto access = tensor->getAccess(ACCESS_READ);
     float* tensorData = access->getRawData();
-    if(dims == 5) {
+    if(dims == 4) {
         outputDepth = shape[dims - 4];
     }
     const int size = outputWidth*outputHeight*outputDepth;

--- a/source/FAST/Algorithms/TissueSegmentation/TissueSegmentation.cpp
+++ b/source/FAST/Algorithms/TissueSegmentation/TissueSegmentation.cpp
@@ -11,6 +11,15 @@ TissueSegmentation::TissueSegmentation() {
     createOutputPort<Segmentation>(0);
 
     createOpenCLProgram(Config::getKernelSourcePath() + "/Algorithms/TissueSegmentation/TissueSegmentation.cl");
+    createIntegerAttribute("threshold", "Intensity threshold", "", m_thresh);
+    createIntegerAttribute("dilate-kernel-size", "Kernel size for dilation", "", m_dilate);
+    createIntegerAttribute("erode-kernel-size", "Kernel size for erosion", "", m_erode);
+}
+
+void TissueSegmentation::loadAttributes() {
+    setThreshold(getIntegerAttribute("threshold"));
+    setDilate(getIntegerAttribute("dilate-kernel-size"));
+    setErode(getIntegerAttribute("erode-kernel-size"));
 }
 
 void TissueSegmentation::setThreshold(int thresh) {

--- a/source/FAST/Algorithms/TissueSegmentation/TissueSegmentation.hpp
+++ b/source/FAST/Algorithms/TissueSegmentation/TissueSegmentation.hpp
@@ -34,8 +34,9 @@ class FAST_EXPORT TissueSegmentation : public SegmentationAlgorithm {
          * Get current erosion value
          */
         int getErode() const;
+        void loadAttributes() override;
     protected:
-        void execute();
+        void execute() override;
         TissueSegmentation();
     private:
         int m_dilate = 9;

--- a/source/FAST/Examples/Interoperability/CMakeLists.txt
+++ b/source/FAST/Examples/Interoperability/CMakeLists.txt
@@ -1,1 +1,1 @@
-fast_add_example(qtInteroperability qtInteroperability.cpp qtInteroperability.hpp)
+#fast_add_example(qtInteroperability qtInteroperability.cpp qtInteroperability.hpp)

--- a/source/FAST/Examples/Interoperability/qtInteroperability.hpp
+++ b/source/FAST/Examples/Interoperability/qtInteroperability.hpp
@@ -90,7 +90,8 @@ class WindowWidget : public QWidget {
                 connect(mThread, SIGNAL(finished()), thread, SLOT(quit()));
                 connect(thread, SIGNAL(finished()), thread, SLOT(deleteLater()));
 
-                mThread->addView(mView);
+                // TODO FIX
+                //mThread->addView(mView);
 
                 QGLContext* mainGLContext = fast::Window::getMainGLContext();
                 if(!mainGLContext->isValid()) {

--- a/source/FAST/Exporters/ImageExporter.cpp
+++ b/source/FAST/Exporters/ImageExporter.cpp
@@ -1,4 +1,6 @@
 #include "FAST/Exporters/ImageExporter.hpp"
+
+#include <utility>
 #include "FAST/Exception.hpp"
 #include "FAST/Utility.hpp"
 #include "FAST/Data/Image.hpp"
@@ -9,8 +11,8 @@
 namespace fast {
 
 void ImageExporter::setFilename(std::string filename) {
-    mFilename = filename;
-    mIsModified = true;
+    mFilename = std::move(filename);
+    setModified(true);
 }
 
 void ImageExporter::loadAttributes() {
@@ -20,14 +22,13 @@ void ImageExporter::loadAttributes() {
 ImageExporter::ImageExporter() {
     createInputPort<Image>(0);
     mFilename = "";
-    mIsModified = true;
 
     createStringAttribute("filename", "Filename", "Path to file to load", mFilename);
 }
 
 void ImageExporter::execute() {
 #ifdef FAST_MODULE_VISUALIZATION
-    if(mFilename == "")
+    if(mFilename.empty())
         throw Exception("No filename given to ImageExporter");
 
     auto input = getInputData<Image>();
@@ -35,7 +36,7 @@ void ImageExporter::execute() {
     if(input->getDimensions() != 2)
         throw Exception("Input image to ImageExporter must be 2D.");
 
-    auto format = QImage::Format_RGB32;
+    auto format = QImage::Format_RGBA8888;
     int Qchannels = 4;
     if(input->getNrOfChannels() == 1) {
         format = QImage::Format_Grayscale8;

--- a/source/FAST/Exporters/ImageExporter.hpp
+++ b/source/FAST/Exporters/ImageExporter.hpp
@@ -15,7 +15,7 @@ class FAST_EXPORT ImageExporter : public ProcessObject {
         void loadAttributes() override;
     private:
         ImageExporter();
-        void execute();
+        void execute() override;
 
         std::string mFilename;
 };

--- a/source/FAST/Exporters/ImageFileExporter.cpp
+++ b/source/FAST/Exporters/ImageFileExporter.cpp
@@ -3,11 +3,12 @@
 #include "ImageExporter.hpp"
 #include "FAST/Data/Image.hpp"
 #include <algorithm>
+#include <utility>
 
 namespace fast {
 
 void ImageFileExporter::setFilename(std::string filename) {
-    mFilename = filename;
+    mFilename = std::move(filename);
     mIsModified = true;
 }
 
@@ -24,7 +25,7 @@ inline bool matchExtension(std::string extension, std::string extension2) {
 }
 
 void ImageFileExporter::execute() {
-    if(mFilename == "")
+    if(mFilename.empty())
         throw Exception("No filename was given to the ImageFileExporter");
 
     Image::pointer input = getInputData<Image>();

--- a/source/FAST/Exporters/ImageFileExporter.hpp
+++ b/source/FAST/Exporters/ImageFileExporter.hpp
@@ -11,7 +11,7 @@ class FAST_EXPORT ImageFileExporter : public ProcessObject {
         ImageFileExporter();
         void setCompression(bool compress);
     private:
-        void execute();
+        void execute() override;
 
         std::string mFilename;
         bool mCompress = false;

--- a/source/FAST/Exporters/ImagePyramidPatchExporter.cpp
+++ b/source/FAST/Exporters/ImagePyramidPatchExporter.cpp
@@ -77,6 +77,7 @@ void ImagePyramidPatchExporter::exportPatch(std::shared_ptr<Image> patch) {
 
 void ImagePyramidPatchExporter::setPath(std::string path) {
     m_path = std::move(path);
+    setModified(true);
 }
 
 void ImagePyramidPatchExporter::setPatchSize(uint width, uint height) {

--- a/source/FAST/Exporters/ImagePyramidPatchExporter.hpp
+++ b/source/FAST/Exporters/ImagePyramidPatchExporter.hpp
@@ -38,7 +38,7 @@ class FAST_EXPORT ImagePyramidPatchExporter : public ProcessObject {
         int m_level = 0;
         int m_patchWidth = 512;
         int m_patchHeight = 512;
-        std::string m_path = "";
+        std::string m_path;
 };
 
 }

--- a/source/FAST/Importers/HDF5TensorImporter.cpp
+++ b/source/FAST/Importers/HDF5TensorImporter.cpp
@@ -54,5 +54,4 @@ void HDF5TensorImporter::execute() {
 	addOutputData(0, tensor);
 }
 
-
 }

--- a/source/FAST/Importers/ImageFileImporter.cpp
+++ b/source/FAST/Importers/ImageFileImporter.cpp
@@ -8,11 +8,12 @@
 #endif
 #include "FAST/Data/Image.hpp"
 #include <algorithm>
+#include <utility>
 
 namespace fast {
 
 void ImageFileImporter::setFilename(std::string filename) {
-    mFilename = filename;
+    mFilename = std::move(filename);
     mIsModified = true;
 }
 
@@ -32,7 +33,7 @@ inline bool matchExtension(std::string extension, std::string extension2) {
 }
 
 void ImageFileImporter::execute() {
-    if(mFilename == "")
+    if(mFilename.empty())
         throw Exception("No filename was given to the ImageFileImporter");
 
     if(!fileExists(mFilename))

--- a/source/FAST/Importers/ImageFileImporter.hpp
+++ b/source/FAST/Importers/ImageFileImporter.hpp
@@ -12,7 +12,7 @@ class FAST_EXPORT  ImageFileImporter : public ProcessObject {
         void loadAttributes() override;
     private:
         ImageFileImporter();
-        void execute();
+        void execute() override;
 
         std::string mFilename;
 };

--- a/source/FAST/Importers/ImageImporter.cpp
+++ b/source/FAST/Importers/ImageImporter.cpp
@@ -7,11 +7,12 @@
 #include "FAST/Data/Image.hpp"
 #include <cctype>
 #include <algorithm>
+#include <utility>
 
 namespace fast {
 
 void ImageImporter::execute() {
-    if (mFilename == "")
+    if(mFilename.empty())
         throw Exception("No filename was supplied to the ImageImporter");
 
     uchar* convertedPixelData;
@@ -86,8 +87,9 @@ void ImageImporter::setGrayscale(bool grayscale) {
 }
 
 void ImageImporter::setFilename(std::string filename) {
-    mFilename = filename;
+    mFilename = std::move(filename);
     mIsModified = true;
+    setModified(true);
 }
 
 }

--- a/source/FAST/Importers/ImageImporter.cpp
+++ b/source/FAST/Importers/ImageImporter.cpp
@@ -74,7 +74,6 @@ void ImageImporter::loadAttributes() {
 
 ImageImporter::ImageImporter() {
     mFilename = "";
-    mIsModified = true;
     mGrayscale = true;
     createOutputPort<Image>(0);
 
@@ -84,11 +83,11 @@ ImageImporter::ImageImporter() {
 
 void ImageImporter::setGrayscale(bool grayscale) {
     mGrayscale = grayscale;
+    setModified(true);
 }
 
 void ImageImporter::setFilename(std::string filename) {
     mFilename = std::move(filename);
-    mIsModified = true;
     setModified(true);
 }
 

--- a/source/FAST/Importers/ImageImporter.hpp
+++ b/source/FAST/Importers/ImageImporter.hpp
@@ -5,7 +5,7 @@
 
 namespace fast {
 
-class FAST_EXPORT  ImageImporter : public Importer {
+class FAST_EXPORT ImageImporter : public Importer {
     FAST_OBJECT(ImageImporter)
     public:
         void setFilename(std::string filename);
@@ -15,10 +15,8 @@ class FAST_EXPORT  ImageImporter : public Importer {
         ImageImporter();
         std::string mFilename;
         bool mGrayscale;
-        void execute();
-
+        void execute() override;
 };
-
 
 } // end namespace fast
 

--- a/source/FAST/Importers/ImagePyramidPatchImporter.cpp
+++ b/source/FAST/Importers/ImagePyramidPatchImporter.cpp
@@ -2,6 +2,7 @@
 #include "ImageImporter.hpp"
 #include <FAST/Data/ImagePyramid.hpp>
 #include <FAST/Data/Image.hpp>
+#include <utility>
 
 namespace fast {
 
@@ -12,7 +13,8 @@ ImagePyramidPatchImporter::ImagePyramidPatchImporter() {
 }
 
 void ImagePyramidPatchImporter::setPath(std::string path) {
-    m_path = path;
+    m_path = std::move(path);
+    setModified(true);
 }
 
 void ImagePyramidPatchImporter::loadAttributes() {

--- a/source/FAST/Importers/ImagePyramidPatchImporter.hpp
+++ b/source/FAST/Importers/ImagePyramidPatchImporter.hpp
@@ -20,7 +20,6 @@ class FAST_EXPORT ImagePyramidPatchImporter : public ProcessObject {
         void execute() override;
 
         std::string m_path;
-        bool mIsModified = true;
 };
 
 }

--- a/source/FAST/Importers/ImagePyramidPatchImporter.hpp
+++ b/source/FAST/Importers/ImagePyramidPatchImporter.hpp
@@ -20,6 +20,7 @@ class FAST_EXPORT ImagePyramidPatchImporter : public ProcessObject {
         void execute() override;
 
         std::string m_path;
+        bool mIsModified = true;
 };
 
 }

--- a/source/FAST/Visualization/Plotting/LinePlotter.hpp
+++ b/source/FAST/Visualization/Plotting/LinePlotter.hpp
@@ -4,6 +4,7 @@
 namespace fast {
 
 FAST_SIMPLE_DATA_OBJECT(FloatScalar, float);
+FAST_SIMPLE_DATA_OBJECT(FloatPoint, Vector2f);
 
 // Input data objects: simple data object: float.., create one line per input connection
 // Redraw whenever new data arrives
@@ -14,6 +15,7 @@ public:
     uint addInputConnection(DataChannel::pointer channel, std::string name = "");
     //uint addInputConnection(DataChannel::pointer channel, std::string name, Color color);
     void setBufferSize(int size);
+    void addHorizontalLine(float x, Color color = Color::Green());
 public slots:
     void processQueue();
 protected:
@@ -22,10 +24,11 @@ protected:
     int m_bufferSize = 64;
     std::map<uint, std::vector<double>> m_buffer;
     std::mutex m_queueMutex;
-    std::deque<std::map<int, float>> m_queue;
+    std::deque<std::map<int, Vector2f>> m_queue;
     std::vector<double> m_xAxis;
     int m_currentIndex = 0;
     std::map<uint, std::string> m_names;
+    std::uint64_t m_frameCounter = 0;
 };
 
 }

--- a/source/FAST/Visualization/SegmentationPyramidRenderer/SegmentationPyramidRenderer.cpp
+++ b/source/FAST/Visualization/SegmentationPyramidRenderer/SegmentationPyramidRenderer.cpp
@@ -83,6 +83,7 @@ SegmentationPyramidRenderer::SegmentationPyramidRenderer() : Renderer() {
 void SegmentationPyramidRenderer::loadAttributes() {
     setOpacity(getFloatAttribute("opacity"));
 }
+
 void SegmentationPyramidRenderer::draw(Matrix4f perspectiveMatrix, Matrix4f viewingMatrix, float zNear, float zFar, bool mode2D) {
     if(mDataToRender.empty())
         return;
@@ -546,7 +547,6 @@ void SegmentationPyramidRenderer::draw(Matrix4f perspectiveMatrix, Matrix4f view
 void SegmentationPyramidRenderer::drawTextures(Matrix4f &perspectiveMatrix, Matrix4f &viewingMatrix, bool mode2D) {
 
 }
-
 
 void SegmentationPyramidRenderer::setOpacity(float opacity) {
     if(opacity < 0 || opacity > 1)


### PR DESCRIPTION
1. Added fix to ensure that import/export of low and high-res images are being properly exported in C++.
2. Added small fix for RGB/BGR switch in ImageExporter.
**3. Added option to set attributes through text pipelines for a selection of classes.**
**4. Added method to set the tissue acceptance threshold (which was hard-coded to 0.5).**
**5. Lowered the image pyramidal plane size threshold to accept lower image planes in the stitcher, which were relevant in a study. I left a comment in the code if we want to switch back and compare in the future.**
**6. Also did some minor refactoring to keep the code more consistent on a selection of files.**

Tested this using FastPathology on Ubuntu, both through C++ and runPipeline. Both worked fine.

(1) The bug was found comparing the specific classes against HDF5TensorExporter/HDF5TensorImporter, which seemed to work great. Using these two scripts as reference I noticed some minor differences.

I found that adding `setModified(true)` was quite important. I'm not really sure why not just using `mIsModified=true` did not work. Perhaps there was something I forgot to add to the header. Now there are occasions where I am using both `setModified(true)` AND `mIsModified=true`, where the latter is then probably redundant? Perhaps it is easier for you to say what is correct, so I just left it like this for you to evaluate.

I am also assuming that there should be an `override` for the execute method if the parent class has an execute method already. I noticed that this was done for the HDF5TensorExporter, and not the specific scripts I was working with. However, in this case it did not really seem to matter.

(2) I noticed that when creating thumbnail images from WSIs, that the exported images had swapped RGB channels. I proposed a simple fix that I have used earlier, but perhaps there is a more elegant solution. This should reproduce the bug:
auto importer = WholeSlideImageImporter::New();
importer->setFilename(path_to_wsi);
auto currImage = importer->updateAndGetOutputData<ImagePyramid>();

auto access = currImage->getAccess(ACCESS_READ);
auto input = access->getLevelAsImage(currImage->getNrOfLevels() - 1)

auto exporter = ImageExporter::New();
exporter->setFilename(path_to_output.png);
exporter->setInputData(input);
exporter->update();

**(5) Perhaps this threshold should even be a hyperparameter one could set? But for now, I just manually lowered them. Did not notice any real difference using runPipeline and FastPathology on Ubuntu, for A05.svs and a larger 40x WSI from a local cohort. But perhaps overall runtime of high-res models will be slower? Right? But perhaps this is okay for now?**

Let me know if there are any requests.