### PR TITLE
Bug: Fixed setColor(s) for SegmentationLabelRenderer

### DIFF
--- a/source/FAST/Visualization/LabelColorRenderer.cpp
+++ b/source/FAST/Visualization/LabelColorRenderer.cpp
@@ -3,41 +3,39 @@
 namespace fast {
 
 void LabelColorRenderer::createColorUniformBufferObject() {
-    if (m_colorsModified) {
-        // Create UBO for colors
-        glDeleteBuffers(1, &m_colorsUBO);
-        glGenBuffers(1, &m_colorsUBO);
-        int maxLabel = 0;
-        for (auto &&labelColor : m_labelColors) {
-            if (labelColor.first > maxLabel)
-                maxLabel = labelColor.first;
-        }
-        auto colorData = std::make_unique<float[]>((maxLabel + 1) * 4);
-        colorData[0] = 1.0f;
-        colorData[1] = 0.0f;
-        colorData[2] = 0.0f;
-        colorData[3] = 1.0f;
-        for(int i = 1; i <= maxLabel; ++i) {
-            if (m_labelColors.count(i) > 0) {
-                colorData[i * 4 + 0] = m_labelColors[i].getRedValue();
-                colorData[i * 4 + 1] = m_labelColors[i].getGreenValue();
-                colorData[i * 4 + 2] = m_labelColors[i].getBlueValue();
-            } else {
-                colorData[i * 4 + 0] = m_defaultColor.getRedValue();
-                colorData[i * 4 + 1] = m_defaultColor.getGreenValue();
-                colorData[i * 4 + 2] = m_defaultColor.getBlueValue();
-            }
-            colorData[i * 4 + 3] = 1.0f;
-        }
-        glBindBuffer(GL_UNIFORM_BUFFER, m_colorsUBO);
-        glBufferData(GL_UNIFORM_BUFFER, sizeof(float) * 4 * (maxLabel + 1), colorData.get(), GL_STATIC_DRAW);
-        glBindBuffer(GL_UNIFORM_BUFFER, 0);
-        m_colorsModified = false;
+    // Create UBO for colors
+    glDeleteBuffers(1, &m_colorsUBO);
+    glGenBuffers(1, &m_colorsUBO);
+    int maxLabel = 0;
+    for (auto &&labelColor : m_labelColors) {
+        if (labelColor.first > maxLabel)
+            maxLabel = labelColor.first;
     }
+    auto colorData = std::make_unique<float[]>((maxLabel + 1) * 4);
+    colorData[0] = 1.0f;
+    colorData[1] = 0.0f;
+    colorData[2] = 0.0f;
+    colorData[3] = 1.0f;
+    for(int i = 1; i <= maxLabel; ++i) {
+        if (m_labelColors.count(i) > 0) {
+            colorData[i * 4 + 0] = m_labelColors[i].getRedValue();
+            colorData[i * 4 + 1] = m_labelColors[i].getGreenValue();
+            colorData[i * 4 + 2] = m_labelColors[i].getBlueValue();
+        } else {
+            colorData[i * 4 + 0] = m_defaultColor.getRedValue();
+            colorData[i * 4 + 1] = m_defaultColor.getGreenValue();
+            colorData[i * 4 + 2] = m_defaultColor.getBlueValue();
+        }
+        colorData[i * 4 + 3] = 1.0f;
+    }
+    glBindBuffer(GL_UNIFORM_BUFFER, m_colorsUBO);
+    glBufferData(GL_UNIFORM_BUFFER, sizeof(float) * 4 * (maxLabel + 1), colorData.get(), GL_STATIC_DRAW);
+    glBindBuffer(GL_UNIFORM_BUFFER, 0);
 }
 
 void LabelColorRenderer::setColor(int label, Color color) {
     m_labelColors[label] = color;
+    setModified(true);
 }
 
 LabelColorRenderer::~LabelColorRenderer() noexcept {
@@ -48,6 +46,7 @@ void LabelColorRenderer::setColors(std::map<uint, Color> colors) {
     m_labelColors = std::move(colors);
     if(m_labelColors.count(255) == 0)
         m_labelColors[255] = Color::Cyan();
+    setModified(true);
 }
 
 }

--- a/source/FAST/Visualization/LabelColorRenderer.cpp
+++ b/source/FAST/Visualization/LabelColorRenderer.cpp
@@ -3,38 +3,43 @@
 namespace fast {
 
 void LabelColorRenderer::createColorUniformBufferObject() {
-    // Create UBO for colors
-    glDeleteBuffers(1, &m_colorsUBO);
-    glGenBuffers(1, &m_colorsUBO);
-    int maxLabel = 0;
-    for (auto &&labelColor : m_labelColors) {
-        if (labelColor.first > maxLabel)
-            maxLabel = labelColor.first;
-    }
-    auto colorData = std::make_unique<float[]>((maxLabel + 1) * 4);
-    colorData[0] = 1.0f;
-    colorData[1] = 0.0f;
-    colorData[2] = 0.0f;
-    colorData[3] = 1.0f;
-    for(int i = 1; i <= maxLabel; ++i) {
-        if (m_labelColors.count(i) > 0) {
-            colorData[i * 4 + 0] = m_labelColors[i].getRedValue();
-            colorData[i * 4 + 1] = m_labelColors[i].getGreenValue();
-            colorData[i * 4 + 2] = m_labelColors[i].getBlueValue();
-        } else {
-            colorData[i * 4 + 0] = m_defaultColor.getRedValue();
-            colorData[i * 4 + 1] = m_defaultColor.getGreenValue();
-            colorData[i * 4 + 2] = m_defaultColor.getBlueValue();
+    if (m_colorsModified) {
+        // Create UBO for colors
+        glDeleteBuffers(1, &m_colorsUBO);
+        glGenBuffers(1, &m_colorsUBO);
+        int maxLabel = 0;
+        for (auto&& labelColor : m_labelColors) {
+            if (labelColor.first > maxLabel)
+                maxLabel = labelColor.first;
         }
-        colorData[i * 4 + 3] = 1.0f;
+        auto colorData = std::make_unique<float[]>((maxLabel + 1) * 4);
+        colorData[0] = 1.0f;
+        colorData[1] = 0.0f;
+        colorData[2] = 0.0f;
+        colorData[3] = 1.0f;
+        for (int i = 1; i <= maxLabel; ++i) {
+            if (m_labelColors.count(i) > 0) {
+                colorData[i * 4 + 0] = m_labelColors[i].getRedValue();
+                colorData[i * 4 + 1] = m_labelColors[i].getGreenValue();
+                colorData[i * 4 + 2] = m_labelColors[i].getBlueValue();
+            }
+            else {
+                colorData[i * 4 + 0] = m_defaultColor.getRedValue();
+                colorData[i * 4 + 1] = m_defaultColor.getGreenValue();
+                colorData[i * 4 + 2] = m_defaultColor.getBlueValue();
+            }
+            colorData[i * 4 + 3] = 1.0f;
+        }
+        glBindBuffer(GL_UNIFORM_BUFFER, m_colorsUBO);
+        glBufferData(GL_UNIFORM_BUFFER, sizeof(float) * 4 * (maxLabel + 1), colorData.get(), GL_STATIC_DRAW);
+        glBindBuffer(GL_UNIFORM_BUFFER, 0);
+        m_colorsModified = false;
     }
-    glBindBuffer(GL_UNIFORM_BUFFER, m_colorsUBO);
-    glBufferData(GL_UNIFORM_BUFFER, sizeof(float) * 4 * (maxLabel + 1), colorData.get(), GL_STATIC_DRAW);
-    glBindBuffer(GL_UNIFORM_BUFFER, 0);
 }
 
 void LabelColorRenderer::setColor(int label, Color color) {
     m_labelColors[label] = color;
+    m_colorsModified = true;
     setModified(true);
 }
 
@@ -46,6 +51,7 @@ void LabelColorRenderer::setColors(std::map<uint, Color> colors) {
     m_labelColors = std::move(colors);
     if(m_labelColors.count(255) == 0)
         m_labelColors[255] = Color::Cyan();
+    m_colorsModified = true;
     setModified(true);
 }
 

--- a/source/FAST/Visualization/LabelColorRenderer.hpp
+++ b/source/FAST/Visualization/LabelColorRenderer.hpp
@@ -22,6 +22,7 @@ class FAST_EXPORT LabelColorRenderer : public virtual Renderer {
                 {7, Color::Brown()},
                 {255, Color::Cyan()},
         };
+        bool m_colorsModified = true;
         uint m_colorsUBO;
         Color m_defaultColor = Color::Green();
     private:

--- a/source/FAST/Visualization/LabelColorRenderer.hpp
+++ b/source/FAST/Visualization/LabelColorRenderer.hpp
@@ -22,7 +22,6 @@ class FAST_EXPORT LabelColorRenderer : public virtual Renderer {
                 {7, Color::Brown()},
                 {255, Color::Cyan()},
         };
-        bool m_colorsModified = true;
         uint m_colorsUBO;
         Color m_defaultColor = Color::Green();
     private:


### PR DESCRIPTION
I believe this used to work before SegmentationRenderer and SegmentationPyramidRenderer were merged. Perhaps it is due to the introduction (?) of SegmentationLabelRenderer, which I was not aware of.

Anyways, AFAIK, the correct way of setting colors such that they can be properly updated later on, is to use `setModified(true)`. I believe you have told me that having a "local" m_colorsModified is not ideal, as one should use the setModified method, which is used for all other POs, instead.

However, for the `createColorUniformBufferObject` I wasn't sure if it was correct to simply remove that if-statement. Maybe this function will be run redundantly in other classes? Currently it is only being used in the [BoundingBoxRenderer](https://github.com/smistad/FAST/blob/a8418d2f2c58d073fc6ae87fea9a880fdced0ade/source/FAST/Visualization/BoundingBoxRenderer/BoundingBoxRenderer.cpp#L39) and the [SegmentationRenderer](https://github.com/smistad/FAST/blob/0acafd59eca0a36d82830ada08707445c61496c7/source/FAST/Visualization/SegmentationRenderer/SegmentationRenderer.cpp#L53).

Anyway, I tested this fix on FastPathology (Windows) and it seems to work well, both for low-res and high-res. But would be nice to know if I should do something else regarding the `createColorUniformBufferObject` method.

**EDIT:** I just tested for bounding boxes as well, and that works!