### PR TITLE
Add interpolate attribute to ImageResizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build*/
 TestData/
 .idea/
+.vs/
 *.cl.bin
 *cl.cache
 .cproject

--- a/source/FAST/Algorithms/ImageResizer/ImageResizer.cpp
+++ b/source/FAST/Algorithms/ImageResizer/ImageResizer.cpp
@@ -43,6 +43,7 @@ void ImageResizer::loadAttributes() {
     setHeight(size[1]);
     if(size.size() == 3)
         setDepth(size[2]);
+    setInterpolation(getBooleanAttribute("interpolate"));
 }
 
 ImageResizer::ImageResizer() {
@@ -57,6 +58,7 @@ ImageResizer::ImageResizer() {
     mInterpolation = true;
 
     createIntegerAttribute("size", "Size", "Size", 0);
+    createBooleanAttribute("interpolate", "Whether to interpolate", "", mInterpolation);
 }
 
 ImageResizer::ImageResizer(int width, int height, int depth, bool useInterpolation, bool preserveAspectRatio) : ImageResizer() {


### PR DESCRIPTION
When testing some pipelines, I found that I was unable to set whether or not to interpolate when using ImageResizer in a FAST pipeline. I have made the necessary edits.

I also found it convenient to add the vs/ directory to the .gitignore, to avoid it being added/pushed when developing on Windows.

I tested this using FastPathology on windows. Seems to work.