### PR TITLE
batch generation pipeline support

### DIFF
--- a/source/FAST/Algorithms/ImagePatch/ImageToBatchGenerator.cpp
+++ b/source/FAST/Algorithms/ImagePatch/ImageToBatchGenerator.cpp
@@ -9,10 +9,17 @@ ImageToBatchGenerator::ImageToBatchGenerator() {
     createOutputPort<Batch>(0);
 
     m_maxBatchSize = -1;
+    mIsModified = true;
+
+    createIntegerAttribute("max-batch-size", "Maximum batch size", "", m_maxBatchSize);
 }
 
 ImageToBatchGenerator::ImageToBatchGenerator(int maxBatchSize) : ImageToBatchGenerator() {
     setMaxBatchSize(maxBatchSize);
+}
+
+void ImageToBatchGenerator::loadAttributes() {
+    setMaxBatchSize(getIntegerAttribute("max-batch-size"));
 }
 
 void ImageToBatchGenerator::generateStream() {
@@ -61,13 +68,13 @@ void ImageToBatchGenerator::generateStream() {
 }
 
 void ImageToBatchGenerator::execute() {
-    if(m_maxBatchSize == 1)
+    if(m_maxBatchSize == -1)
         throw Exception("Max batch size must be given to the ImageToBatchGenerator");
 
     if(!m_streamIsStarted) {
         m_streamIsStarted = true;
         mParent = mInputConnections[0];
-        mInputConnections.clear(); // Severe the connection
+        //mInputConnections.clear(); // Severe the connection  @FIXME: haivng this results in "Input port X is missing its required connection when streaming. Hence, I removed this. Why was it used?"
         m_thread = std::make_unique<std::thread>(std::bind(&ImageToBatchGenerator::generateStream, this));
     }
 

--- a/source/FAST/Algorithms/ImagePatch/ImageToBatchGenerator.hpp
+++ b/source/FAST/Algorithms/ImagePatch/ImageToBatchGenerator.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <FAST/ProcessObject.hpp>
 #include <FAST/Streamers/Streamer.hpp>
 #include <thread>
 
@@ -25,6 +26,7 @@ class FAST_EXPORT ImageToBatchGenerator : public Streamer {
         FAST_CONSTRUCTOR(ImageToBatchGenerator, int, maxBatchSize,);
         void setMaxBatchSize(int size);
         ~ImageToBatchGenerator() override;
+        void loadAttributes() override;
     protected:
         void execute() override;
         void generateStream() override;


### PR DESCRIPTION
Tested with runPipeline method using patch-wise classifier in FastPathology using Win10.

Seems to do what it should. I observe that patches are being rendered in sets, after a batch is finished processing. Increasing the `max-batch-size` makes this more apparent.

However, I did not observe that memory usage (GPU) increased that much, perhaps not any. Is inference performed per-patch or on batch-level, when passing output from ImageToBatchGenerator PO to NeuralNetwork PO?

Also note my comment below. I had to remove the `mInputConnections.clear()` to make the PO work in a pipeline (see [here](https://github.com/smistad/FAST/blob/a8418d2f2c58d073fc6ae87fea9a880fdced0ade/source/FAST/Algorithms/ImagePatch/ImageToBatchGenerator.cpp#L70)). Is this correct? What is the reason it was done in the first place?