### PR TITLE
Add support for forwarding IGTL String messages in the OpenIGTLinkStreamer

### DIFF
--- a/source/FAST/Streamers/OpenIGTLinkStreamer.cpp
+++ b/source/FAST/Streamers/OpenIGTLinkStreamer.cpp
@@ -31,8 +31,8 @@ void OpenIGTLinkStreamer::setConnectionPort(uint port) {
 }
 
 DataChannel::pointer OpenIGTLinkStreamer::getOutputPort(uint portID) {
-    if(getNrOfInputPorts() == 0) {
-        int portID = getOutputPortNumber("");
+    if(getNrOfOutputPorts() == 0) {
+        portID = getOutputPortNumber("");
     }
 	return Streamer::getOutputPort(portID);
 }
@@ -83,6 +83,7 @@ std::vector<std::string> OpenIGTLinkStreamer::getActiveTransformStreamNames() {
 static Image::pointer createFASTImageFromMessage(igtl::ImageMessage::Pointer message, ExecutionDevice::pointer device) {
     int width, height, depth;
     message->GetDimensions(width, height, depth);
+    std::cout << "Got image of size: " << width << " " << height << " " << depth << std::endl;
     void* data = message->GetScalarPointer();
     DataType type;
     switch(message->GetScalarType()) {
@@ -322,6 +323,7 @@ void OpenIGTLinkStreamer::generateStream() {
                     image->setCreationTimestamp(timestamp);
                     addTimestamp(timestamp);
                     addOutputData(mOutputPortDeviceNames[deviceName], image);
+                    std::cout << "Added image message to " << deviceName << " " << mOutputPortDeviceNames[deviceName] << std::endl;
                 } catch(NoMoreFramesException &e) {
                     throw e;
                 } catch(Exception &e) {
@@ -379,11 +381,12 @@ void OpenIGTLinkStreamer::generateStream() {
             stringMsg->Unpack();
             auto message = stringMsg->GetString();
 
-            FASTString::pointer fastStringMsg = FASTString::create(message);
-            fastStringMsg->setCreationTimestamp(timestamp);
+            auto fastString = String::create(message);
+            fastString->setCreationTimestamp(timestamp);
 
             addTimestamp(timestamp);
-            addOutputData(mOutputPortDeviceNames[deviceName], fastStringMsg);
+            addOutputData(mOutputPortDeviceNames[deviceName], fastString);
+            std::cout << "Added string message to " << deviceName << " " << mOutputPortDeviceNames[deviceName] << std::endl;
        } else {
            // Receive generic message
           igtl::MessageBase::Pointer message;

--- a/source/FAST/Streamers/OpenIGTLinkStreamer.hpp
+++ b/source/FAST/Streamers/OpenIGTLinkStreamer.hpp
@@ -4,9 +4,11 @@
 #include <unordered_map>
 #include "FAST/Streamers/Streamer.hpp"
 #include "FAST/ProcessObject.hpp"
+#include "FAST/Data/SimpleDataObject.hpp"
 #include <set>
 #include "FASTExport.hpp"
 #include <deque>
+#include <string>
 
 // Forward declare
 
@@ -14,6 +16,9 @@ namespace fast {
 
 class Image;
 class IGTLSocketWrapper;
+
+FAST_SIMPLE_DATA_OBJECT(FASTString, std::string);
+
 
 /**
  * @brief Stream image or transforms from an OpenIGTLink server

--- a/source/FAST/Streamers/OpenIGTLinkStreamer.hpp
+++ b/source/FAST/Streamers/OpenIGTLinkStreamer.hpp
@@ -17,7 +17,8 @@ namespace fast {
 class Image;
 class IGTLSocketWrapper;
 
-FAST_SIMPLE_DATA_OBJECT(FASTString, std::string);
+// Should be moved somewhere else, but for now it is only used by OpenIGTLinkStreamer
+FAST_SIMPLE_DATA_OBJECT(String, std::string);
 
 
 /**

--- a/source/FAST/Streamers/Streamer.cpp
+++ b/source/FAST/Streamers/Streamer.cpp
@@ -61,15 +61,15 @@ void Streamer::setStreamingMode(StreamingMode mode) {
 }
 
 DataChannel::pointer Streamer::getOutputPort(uint portID) {
-    if(!m_outputPO) {
+    if(m_outputPOs.count(portID) == 0) {
         auto channel = ProcessObject::getOutputPort(portID);
-        m_outputPO = RunLambda::create([](DataObject::pointer data) -> DataList {
+        m_outputPOs[portID] = RunLambda::create([](DataObject::pointer data) -> DataList {
             return DataList(data);
         });
-        m_outputPO->setInputConnection(channel);
+        m_outputPOs[portID]->setInputConnection(channel);
     }
 
-    return m_outputPO->getOutputPort();
+    return m_outputPOs[portID]->getOutputPort();
 }
 
 bool Streamer::isStopped() {

--- a/source/FAST/Streamers/Streamer.hpp
+++ b/source/FAST/Streamers/Streamer.hpp
@@ -87,7 +87,7 @@ class FAST_EXPORT Streamer : public ProcessObject {
         std::unique_ptr<std::thread> m_thread;
         std::condition_variable m_firstFrameCondition;
 
-        std::shared_ptr<ProcessObject> m_outputPO;
+        std::map<uint, std::shared_ptr<ProcessObject>> m_outputPOs;
 
 
 };

--- a/source/FAST/Streamers/Tests/OpenIGTLinkStreamerTests.cpp
+++ b/source/FAST/Streamers/Tests/OpenIGTLinkStreamerTests.cpp
@@ -34,24 +34,29 @@ TEST_CASE("Stream 2D images using OpenIGTLinkStreamer", "[OpenIGTLinkStreamer][f
     CHECK_NOTHROW(window->start());
 }
 
+/*
 TEST_CASE("Stream image and string message using OpenIGTLinkStreamer", "[OpenIGTLinkStreamer][fast][IGTLink][visual]") {
 
     auto streamer = OpenIGTLinkStreamer::create("localhost");
 
     auto renderer = ImageRenderer::create();
-    renderer->connect(streamer, streamer->getOutputPortNumber("BMode") );
+    int bmode = streamer->getOutputPortNumber("BMode");
+    int ecg = streamer->getOutputPortNumber("ECG");
+    std::cout << "PORT numbers: " << bmode << " " << ecg << std::endl;
+    renderer->connect(streamer,  bmode);
 
     auto runLambda = RunLambda::create([](DataObject::pointer data) {
-        auto stringMessage = std::dynamic_pointer_cast<FASTString>(data);
+        auto stringMessage = std::dynamic_pointer_cast<String>(data);
         if(stringMessage) {
             std::cout << "String message: " << stringMessage->get() << std::endl;
         }
-        std::cout << data->getNameOfClass() << std::endl;
+        std::cout << "ECG output port gave: " << data->getNameOfClass() << std::endl;
         return DataList(data);
-    })->connect(streamer, streamer->getOutputPortNumber("ECG"));
+    })->connect(streamer, ecg);
 
     auto window = SimpleWindow2D::create()->connect(renderer);
     window->addProcessObject(runLambda);
     window->setTimeout(5000);
     CHECK_NOTHROW(window->start());
 }
+ */

--- a/source/FAST/Streamers/Tests/OpenIGTLinkStreamerTests.cpp
+++ b/source/FAST/Streamers/Tests/OpenIGTLinkStreamerTests.cpp
@@ -4,6 +4,7 @@
 #include "FAST/Visualization/ImageRenderer/ImageRenderer.hpp"
 #include "FAST/Visualization/SimpleWindow.hpp"
 #include "FAST/Algorithms/AddTransformation/AddTransformation.hpp"
+#include <FAST/Algorithms/Lambda/RunLambda.hpp>
 
 using namespace fast;
 
@@ -29,6 +30,28 @@ TEST_CASE("Stream 2D images using OpenIGTLinkStreamer", "[OpenIGTLinkStreamer][f
     renderer->addInputConnection(addTransformation->getOutputPort());
     auto window = SimpleWindow::New();
     window->addRenderer(renderer);
+    window->setTimeout(5000);
+    CHECK_NOTHROW(window->start());
+}
+
+TEST_CASE("Stream image and string message using OpenIGTLinkStreamer", "[OpenIGTLinkStreamer][fast][IGTLink][visual]") {
+
+    auto streamer = OpenIGTLinkStreamer::create("localhost");
+
+    auto renderer = ImageRenderer::create();
+    renderer->connect(streamer, streamer->getOutputPortNumber("BMode") );
+
+    auto runLambda = RunLambda::create([](DataObject::pointer data) {
+        auto stringMessage = std::dynamic_pointer_cast<FASTString>(data);
+        if(stringMessage) {
+            std::cout << "String message: " << stringMessage->get() << std::endl;
+        }
+        std::cout << data->getNameOfClass() << std::endl;
+        return DataList(data);
+    })->connect(streamer, streamer->getOutputPortNumber("ECG"));
+
+    auto window = SimpleWindow2D::create()->connect(renderer);
+    window->addProcessObject(runLambda);
     window->setTimeout(5000);
     CHECK_NOTHROW(window->start());
 }


### PR DESCRIPTION
Passing IGTL String messages could be convenient in several projects. Now Transform, Image and Status is supported, and the code provided is based on that with the aim of supporting String. In addition a simple data object called FASTString based on std::string is added for object passing. The naming was quasi random, so please update if preferred. 

The code runs fine when the only channel is the String, however, combined with Image type (and probably others) it fails and the image channel seem to coup the lambda function provided in the test. Not sure if the error is in RunLambda or the OpenIGTLinkStreamer code. Any ideas?