### PR TITLE
Support for reading TIFF files of data types other than uint8

### DIFF
--- a/source/FAST/Data/ImagePyramid.hpp
+++ b/source/FAST/Data/ImagePyramid.hpp
@@ -22,7 +22,7 @@ class Image;
 class FAST_EXPORT ImagePyramid : public SpatialDataObject {
     FAST_DATA_OBJECT(ImagePyramid)
     public:
-        FAST_CONSTRUCTOR(ImagePyramid, int, width,, int, height,, int, channels,, int, patchWidth, = 256, int, patchHeight, = 256, ImageCompression, compression, = ImageCompression::UNSPECIFIED);
+        FAST_CONSTRUCTOR(ImagePyramid, int, width,, int, height,, int, channels,, int, patchWidth, = 256, int, patchHeight, = 256, ImageCompression, compression, = ImageCompression::UNSPECIFIED, DataType, dataType, = TYPE_UINT8);
         FAST_CONSTRUCTOR(ImagePyramid, openslide_t*, fileHandle,, std::vector<ImagePyramidLevel>, levels,);
         FAST_CONSTRUCTOR(ImagePyramid, std::ifstream*, stream,, std::vector<vsi_tile_header>, tileHeaders,, std::vector<ImagePyramidLevel>, levels,, ImageCompression, compressionFormat,);
         FAST_CONSTRUCTOR(ImagePyramid, TIFF*, fileHandle,, std::vector<ImagePyramidLevel>, levels,, int, channels,,bool, isOMETIFF, = false);
@@ -74,6 +74,7 @@ class FAST_EXPORT ImagePyramid : public SpatialDataObject {
         std::shared_ptr<NeuralNetwork> getCompressionModel() const;
         std::shared_ptr<NeuralNetwork> getDecompressionModel() const;
         float getDecompressionOutputScaleFactor() const;
+        DataType getDataType() const;
     private:
         ImagePyramid();
         std::vector<ImagePyramidLevel> m_levels;
@@ -86,6 +87,7 @@ class FAST_EXPORT ImagePyramid : public SpatialDataObject {
         std::string m_tiffPath;
 
         int m_channels;
+        DataType m_dataType = TYPE_UINT8;
         bool m_initialized;
         /**
          * Whether all patches in entire pyramid has been initialized.


### PR DESCRIPTION
TODO

- [x] Check that nothing is broken by this patch

- [ ] Implement support for writing in other data types as well ImagePyramidAccess::setPatch