### PR TITLE
Update Python WSI tutorial documentation

### DIFF
--- a/doc/pages/Python-tutorial-wsi.dox
+++ b/doc/pages/Python-tutorial-wsi.dox
@@ -345,7 +345,7 @@ patchGenerator = fast.PatchGenerator.create(512, 512, level=2)\
 for i, patch in enumerate(fast.DataStream(patchGenerator)):
     patch_name = f"patch_{i}.jpg"
 
-    # Alternatively, if you want to keep track if the tile position and size, it is possible to emulate the filenames produced 
+    # Alternatively, if you want to keep track of the tile position and size, it is possible to emulate the filenames produced 
     # by ImagePyramidPatchExporter as follows:
     # level = int(patch.getFrameData("patch-level"))
     # x_spacing, y_spacing = int(patch.getFrameData("patch-spacing-x")), int(patch.getFrameData("patch-spacing-y")) 


### PR DESCRIPTION
Add a comment showing how to save files from PatchGenerator with the same file name format as ImagePyramidPatchExporter.
This is a follow-up from [the gitter discussion about this topic](https://matrix.to/#/!ywOSUGwbqRmikkJTxY:gitter.im/$0XQTQNZx33XNYKmHQ1SFn7j_mU6jHtQdscLs0i9tnNc?via=gitter.im).

There is now a commented version of the [patch save](https://github.com/smistad/FAST/blob/bf5924572286bd13ada198ff495c843e967adb37/doc/pages/Python-tutorial-wsi.dox#L346) which follows the format used by the [PyramidPatchExporter](https://github.com/smistad/FAST/blob/bf5924572286bd13ada198ff495c843e967adb37/source/FAST/Exporters/ImagePyramidPatchExporter.cpp#L49-L65).